### PR TITLE
Replace `available` usage with `type -q`

### DIFF
--- a/init.fish
+++ b/init.fish
@@ -1,5 +1,5 @@
 function init --on-event init_thefuck
-  if available thefuck
+  if type -q thefuck
     eval (thefuck --alias | tr '\n' ';')  # function stays up-to-date, always
   else
     echo "Please install thefuck first. Check https://github.com/nvbn/thefuck"


### PR DESCRIPTION
`available` isn't super fishy, let's use `type -q` instead. it's quiet, it avoids redirection, and @derekstavis likes it better :P
