### PR TITLE
Add Ctrl+F as a shortcut for "fuck"

### DIFF
--- a/key_bindings.fish
+++ b/key_bindings.fish
@@ -1,0 +1,1 @@
+bind \cf 'fuck; commandline -f repaint'


### PR DESCRIPTION
Using OMF's new support for adding shortcuts from plugins (and themes), I suggest to add Ctrl+F as a shortcut for running `fuck`.
Not sure about this specific binding, but I find it reasonable.
