### PR TITLE
Make stderr redirection compatible with Fish 3.0.

### DIFF
--- a/functions/thefuck-command-line.fish
+++ b/functions/thefuck-command-line.fish
@@ -1,5 +1,5 @@
 function thefuck-command-line
-  env THEFUCK_REQUIRE_CONFIRMATION=0 thefuck $history[1] ^ /dev/null | read fuck
+  env THEFUCK_REQUIRE_CONFIRMATION=0 thefuck $history[1] 2> /dev/null | read fuck
   [ -z $fuck ]; and return
   commandline -r $fuck
 end


### PR DESCRIPTION
Fish has deprecated `^` as a shortcut for stderr redirection in 3.0. Replace it with the more
compatible `2>`.

See oh-my-fish/oh-my-fish#609 and oh-my-fish/oh-my-fish#618